### PR TITLE
Proposed: Add Antenna to CSK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ iceye = [
 ]
 
 cosmo = [
+    "astropy>=6.0.0",
     "h5py>=3.12.1",
     "python-dateutil>=2.9.0",
     "scipy>=1.15.1",
@@ -110,6 +111,7 @@ preview = true
 
 [[tool.mypy.overrides]]
 module = [
+    "astropy.*",
     "h5py.*",
     "lxml.*",
     "scipy.*",


### PR DESCRIPTION
# Description

This branch adds antenna information to the `csk` module that converts CSK and CSG vendor-specific products into SICD products.

# Results

Attached are screenshots showing the result of running the updated converter on a [publicly available dataset](https://earth.esa.int/eogateway/ftp/missions/sample-data/third-party-missions/cosmo-skymed/first-generation/pingpong/SCS_B-hdf5.zip) and then running `python -m sarpy.utils.create_kmz --include-all` against the result.

## Overview

<img width="2560" height="1400" alt="csk-antenna-overview" src="https://github.com/user-attachments/assets/09ee1e57-097c-4c7f-91c7-98d6dce10244" />

## Zoom

<img width="2560" height="1400" alt="csk-antenna-zoom" src="https://github.com/user-attachments/assets/e2bae2f4-8854-47c0-aeb7-fc1a2d2f0b8f" />
