### PR TITLE
Harmonize Converters

### DIFF
--- a/sarkit_convert/tsx.py
+++ b/sarkit_convert/tsx.py
@@ -15,6 +15,7 @@ metadata that would predict the complex data characteristics
 """
 
 import argparse
+import datetime
 import pathlib
 
 import dateutil.parser
@@ -28,6 +29,7 @@ import sarkit.wgs84
 import scipy.constants
 from lxml import etree
 
+from sarkit_convert import __version__
 from sarkit_convert import _utils as utils
 
 NSMAP = {
@@ -154,7 +156,6 @@ def cosar_to_sicd(
     cosar_file,
     sicd_file,
     classification,
-    ostaid,
     chan_index,
     tx_polarizations,
     tx_rcv_pols,
@@ -196,7 +197,7 @@ def cosar_to_sicd(
     application = generation_system.text
     version = generation_system.attrib["version"]
     creation_application = f"{application} version {version}"
-    creation_site = tsx_xml.findtext(
+    originator_facility = tsx_xml.findtext(
         "./productInfo/generationInfo/level1ProcessingFacility"
     )
 
@@ -505,7 +506,6 @@ def cosar_to_sicd(
     image_creation = sicd.ImageCreation(
         sicd.Application(creation_application),
         sicd.DateTime(_naive_to_sicd_str(creation_time)),
-        sicd.Site(creation_site),
     )
     image_data = sicd.ImageData(
         sicd.PixelType(COSAR_PIXEL_TYPE),
@@ -669,6 +669,11 @@ def cosar_to_sicd(
             )
         rcv_channels.addprevious(tx_sequence)
 
+    now = (
+        datetime.datetime.now(datetime.timezone.utc)
+        .isoformat(timespec="microseconds")
+        .replace("+00:00", "Z")
+    )
     image_formation = sicd.ImageFormation(
         sicd.RcvChanProc(sicd.NumChanProc("1"), sicd.ChanIndex(str(chan_index))),
         sicd.TxRcvPolarizationProc(tx_rcv_polarization),
@@ -682,6 +687,10 @@ def cosar_to_sicd(
         sicd.ImageBeamComp("SV"),
         sicd.AzAutofocus("NO"),
         sicd.RgAutofocus("NO"),
+        sicd.Processing(
+            sicd.Type(f"sarkit-convert {__version__} @ {now}"),
+            sicd.Applied("true"),
+        ),
     )
 
     rma = sicd.RMA(
@@ -803,7 +812,7 @@ def cosar_to_sicd(
     metadata = sksicd.NitfMetadata(
         xmltree=sicd_xmltree,
         file_header_part={
-            "ostaid": ostaid,
+            "ostaid": originator_facility,
             "ftitle": core_name,
             "security": {
                 "clas": classification[0].upper(),
@@ -846,11 +855,6 @@ def main(args=None):
         "output_sicd_file",
         type=pathlib.Path,
         help='path of the output SICD file. The string "{pol}" will be replaced with polarization for multiple images',
-    )
-    parser.add_argument(
-        "--ostaid",
-        help="content of the originating station ID (OSTAID) field of the NITF header",
-        default="Unknown",
     )
     config = parser.parse_args(args)
 
@@ -895,7 +899,6 @@ def main(args=None):
             cosar_file=img_info["cosar_filename"],
             sicd_file=img_info["sicd_filename"],
             classification=config.classification,
-            ostaid=config.ostaid,
             chan_index=img_info["chan_index"],
             tx_polarizations=tx_polarizations,
             tx_rcv_pols=tx_rcv_pols,

--- a/tests/iceye/test_iceye.py
+++ b/tests/iceye/test_iceye.py
@@ -21,4 +21,6 @@ def test_main_errors():
         sarkit_convert.iceye.main()
 
     with pytest.raises(FileNotFoundError, match="Unable to synchronously open file"):
-        sarkit_convert.iceye.main(["/fake/path", "U", "/another/fake/path"])
+        sarkit_convert.iceye.main(
+            ["/fake/path", "U", "/another/fake/path", "fake_ostaid"]
+        )


### PR DESCRIPTION
This PR is meant to address discrepancies between the converters so they're more similar in their approach.

1. Use tolerances for poly generation ala TSX
  * The original TSX converter introduced the idea of specifying tolerances during poly creation to determine the poly order. This PR has added this capability to the other converters.
2. Fill out ImageFormation/Processing XML instead of ImageCreation/Profile
  * Removed Profile node and added sarkit-convert version number to a new ImageFormation/Processing node
3. Sync up usage of OSTAID and Site
  * OSTAID is now populated with originator_facility which is gleaned from the RAW file metadata for TSX, and CSG. Sentinel station ID is hardcoded to `ESA` for simplicity.  Iceye OSTAID is not in the metadata, so we'll force the user to include the information when they run the converter.
  * The optional Site node has been removed where it was used.