### PR TITLE
Add numpydoc linting; add to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,29 @@
 
 **sarkit-convert** is a Python library for converting SAR data to standard formats.
 
+## Install
+While some `sarkit-convert` functionality is available using base dependencies, many converter-specific dependencies are
+declared in the packaging extras defined in the [`pyproject.toml`](./pyproject.toml).
+`sarkit-convert` can be installed with one or more of these dependencies using pip:
+
+```sh
+$ python -m pip install sarkit-convert[cosmo,iceye,sentinel,terrasar]
+$ python -m pip install sarkit-convert[all]
+```
+
+`sarkit-convert` can also be installed using conda and the conda-forge channel:
+
+```sh
+$ conda install --channel conda-forge sarkit-convert
+```
+
+The conda-forge package comes with all packaging extras.
+
 ## License
 This repository is licensed under the [MIT license](./LICENSE).
 
+## Contributing and Development
+Contributions are welcome.
 A few tips for getting started using [PDM](https://pdm-project.org/en/latest/) are below:
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,6 +27,11 @@ def lint(session):
         "format",
         "--diff",
     )
+    session.run(
+        "numpydoc",
+        "lint",
+        *((pathlib.Path(__file__).parent / "sarkit_convert").rglob("*.py")),
+    )
     session.run("mypy", pathlib.Path(__file__).parent / "sarkit_convert")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dev-lint = [
     "ruff>=0.3.0",
     "mypy>=1.8.0",
     "types-python-dateutil>=2.9.0",
+    "numpydoc>=1.10.0",
 ]
 dev-test = [
     "pytest>=7.4.4",
@@ -98,6 +99,16 @@ select = [
     "RUF022", # unsorted-dunder-all
 ]
 preview = true
+
+[tool.numpydoc_validation]
+checks = [
+    "GL02",  # Closing quotes should be placed in the line after the last text in the docstring (do not close the quotes in the same line as the text, or leave a blank line between the last text and the quotes)
+    "GL03",  # Double line break found; please use only one blank line to separate sections or paragraphs, and do not leave blank lines at the end of docstrings
+    "GL06",  # Found unknown section "{section}". Allowed sections are: "{allowed_sections}"
+    "GL07",  # Sections are in the wrong order. Correct order is: {correct_sections}
+    "PR03",  # Wrong parameters order
+    "PR10",  # Parameter "{param_name}" requires a space before the colon
+]
 
 [[tool.mypy.overrides]]
 module = [

--- a/sarkit_convert/__init__.py
+++ b/sarkit_convert/__init__.py
@@ -9,7 +9,6 @@ The main namespace is almost empty by design.
 
    * - ``__version__``
      - SARkit-convert version string
-
 """
 
 from sarkit_convert._version import __version__

--- a/sarkit_convert/_utils.py
+++ b/sarkit_convert/_utils.py
@@ -4,7 +4,6 @@ Utility functions for SICD converters
 =====================================
 
 Common utility functions for use in SICD converters
-
 """
 
 import itertools
@@ -77,21 +76,21 @@ def polyfit2d(x, y, z, order1, order2):
 def polyfit2d_tol(x, y, z, max_order_x, max_order_y, tol, strict_tol=False):
     """Fits 2D polys of minimum order to bring the maximum residual under tol.
 
-    Args
-    ----
-    x: array-like
+    Parameters
+    ----------
+    x : array-like
         First independent variable values. One dimensional.
-    y: array-like
+    y : array-like
         Second independent variable values. One dimensional.
-    z: array-like
+    z : array-like
         Dependent variable values. Leading dimension must have same size as `x` and `y` .
-    max_order_x: int
+    max_order_x : int
         The maximum order in `x` to consider
-    max_order_y: int
+    max_order_y : int
         The maximum order in `y` to consider
-    tol: float
+    tol : float
         The maximum residual requested.
-    strict_tol: bool
+    strict_tol : bool
         ``True`` if an exception should be raised if `tol` is not met with allowed orders.
 
         If ``False``, return best fitting polynomial of allowed order.
@@ -105,7 +104,6 @@ def polyfit2d_tol(x, y, z, max_order_x, max_order_y, tol, strict_tol=False):
     ------
     `ValueError`
         If `strict_tol` and tolerance is not reached.
-
     """
     orders = sorted(
         list(itertools.product(range(max_order_x + 1), range(max_order_y + 1))),
@@ -127,11 +125,11 @@ def polyfit2d_tol(x, y, z, max_order_x, max_order_y, tol, strict_tol=False):
 def polyshift(poly, new_origin):
     """Returns new polynomial with shifted origin
 
-    Args
-    ----
-    poly: array-like
+    Parameters
+    ----------
+    poly : array-like
         1d polynomial coefficients, with constant term first
-    new_origin: float
+    new_origin : float
         location in `poly`'s domain to place new polynomial's origin
 
     Returns
@@ -161,15 +159,14 @@ def broadening_from_amp(amp_vals, threshold_db=None):
 
     Parameters
     ----------
-    amp_vals: array-like
+    amp_vals : array-like
         window amplitudes
-    threshold_db: float, optional
+    threshold_db : float, optional
         threshold to use to compute broadening (Default: 10*log10(0.5))
 
     Returns
     -------
     float
-
     """
     if threshold_db is None:
         threshold = np.sqrt(0.5)
@@ -212,7 +209,8 @@ def _get_sigma0_noise(sicd_ew):
 def _get_default_signal_estimate(sicd_ew):
     """Gets default signal for use in the RNIIRS calculation.
 
-    This will be 1.0 for copolar (or unknown) collections, and 0.25 for cross-pole collections."""
+    This will be 1.0 for copolar (or unknown) collections, and 0.25 for cross-pole collections.
+    """
 
     pol = sicd_ew["ImageFormation"].get("TxRcvPolarizationProc", None)
     if pol is None or ":" not in pol:
@@ -231,7 +229,6 @@ def _estimate_rniirs(information_density):
 
     To maintain positivity of the estimated rniirs, this transitions to a linear
     model.
-
     """
     a = RNIIRS_FIT_PARAMETERS
     iim_transition = np.exp(1 - np.log(2) * a[0] / a[1])

--- a/sarkit_convert/cosmo.py
+++ b/sarkit_convert/cosmo.py
@@ -12,7 +12,6 @@ During development, the following documents were considered:
 
 In addition, SARPy was consulted on how to use the CSK/CSG to compute SICD
 metadata that would predict the complex data characteristics
-
 """
 
 import argparse
@@ -104,13 +103,13 @@ def compute_apc_poly(h5_attrs, ref_time, start_time, stop_time):
 
     Parameters
     ----------
-    h5_attrs: dict
+    h5_attrs : dict
         The collection metadata
-    ref_time: datetime.datetime
+    ref_time : datetime.datetime
         The time at which the orbit goes through the `apc_pos`.
-    start_time: datetime.datetime
+    start_time : datetime.datetime
         The start time to fit.
-    stop_time: datetime.datetime
+    stop_time : datetime.datetime
         The end time to fit.
 
     Returns

--- a/sarkit_convert/create_arp_poly.py
+++ b/sarkit_convert/create_arp_poly.py
@@ -59,24 +59,24 @@ def create_arp_poly(
     """Create an aperture reference position polynomial from a subset of metadata
     and orbital parameters
 
-    Args
-    ----
-    scp_pos_ecef: ndarray, shape=(3, )
+    Parameters
+    ----------
+    scp_pos_ecef : ndarray, shape=(3, )
         Scene Center Point position in ecef cartesian coordinates
-    incidence_deg: float
+    incidence_deg : float
         Incidence Angle to SCP during imaging
-    look_direction: float
+    look_direction : float
         SICD SideOfTrack conveyed as float (LEFT -> 1, RIGHT -> -1)
-    orbit_height_m: float
+    orbit_height_m : float
         Orbital height in meters.  Assumed to be constant
-    orbit_inclination_deg: float
+    orbit_inclination_deg : float
         Orbital inclination in degrees
-    angle_to_north_deg: float|None
+    angle_to_north_deg : float or None
         Imaging angle clockwise from north in degrees.  Equivalent to SICD/SCPCOA/AzimAng
-    orbit_direction: float|None
+    orbit_direction : float or None
         Indicates whether the arp velocity should be ascending or descending.
         Sign of this value will determine the sign of the velocity z component
-    doppler_cone_angle_deg: float|None
+    doppler_cone_angle_deg : float or None
         Doppler cone angle at SCP COA in degrees.  Equivalent to SICD/SCPCOA/DopplerConeAng
 
     Returns

--- a/sarkit_convert/iceye.py
+++ b/sarkit_convert/iceye.py
@@ -6,7 +6,6 @@ Iceye Complex to SICD
 Convert a complex image from the Iceye HD5 SLC into SICD.
 
 Note: In the development of this converter "Iceye Product Metadata" description (v2.1, v2.2, v2.4, v2.5) was considered.
-
 """
 
 import argparse
@@ -71,11 +70,11 @@ def compute_apc_poly(h5_attrs, start_time, stop_time):
 
     Parameters
     ----------
-    h5_attrs: dict
+    h5_attrs : dict
         The collection metadata
-    start_time: float
+    start_time : float
         The start time to fit.
-    stop_time: float
+    stop_time : float
         The end time to fit.
 
     Returns
@@ -198,15 +197,14 @@ def hdf5_to_sicd(h5_filename, sicd_filename, classification, ostaid):
 
     Parameters
     ----------
-    h5_filename: str
+    h5_filename : str
         path of the input HDF5 file
-    sicd_filename: str
+    sicd_filename : str
         path of the output SICD file.
-    classification: str
+    classification : str
         content of the /SICD/CollectionInfo/Classification node in the SICD XML.
-    ostaid: str
+    ostaid : str
         content of the originating station ID (OSTAID) field of the NITF header.
-
     """
     with h5py.File(h5_filename, "r") as h5file:
         h5_attrs = _extract_attributes(h5file)

--- a/sarkit_convert/sentinel.py
+++ b/sarkit_convert/sentinel.py
@@ -4,7 +4,6 @@ Sentinel SAFE to SICD
 =====================
 
 Convert a complex image(s) from the Sentinel SAFE to SICD(s).
-
 """
 
 import argparse

--- a/sarkit_convert/sidd_metadata.py
+++ b/sarkit_convert/sidd_metadata.py
@@ -113,7 +113,6 @@ def sidd_projection_from_geotiff(
     See:
       * http://geotiff.maptools.org/spec/geotiff2.5.html
       * http://geotiff.maptools.org/spec/geotiff2.6.html
-
     """
     # Image Coordinates are [I J K 1] -> (column, row, vertical,  1)
     image_coords = np.stack(

--- a/sarkit_convert/terrasar.py
+++ b/sarkit_convert/terrasar.py
@@ -11,7 +11,6 @@ During development, the following documents were considered:
 
 In addition, SARPy was consulted on how to use the TSX metadata to compute SICD
 metadata that would predict the complex data characteristics
-
 """
 
 import argparse
@@ -69,11 +68,11 @@ def _compute_apc_poly(tsx_xml, start_time, stop_time):
 
     Parameters
     ----------
-    tsx_xml: lxml.Element
+    tsx_xml : lxml.etree.Element
         The TSX xml
-    start_time: datetime.datetime
+    start_time : datetime.datetime
         The start time to fit
-    stop_time: datetime.datetime
+    stop_time : datetime.datetime
         The end time to fit
 
     Returns

--- a/sarkit_convert/tle.py
+++ b/sarkit_convert/tle.py
@@ -19,22 +19,21 @@ def _checksum_val(c):
 def parse_tle(lines, lineno=1):
     """Parse a TLE into a dictionary.
 
-    Args
-    ----
-    lines: list of str
+    Parameters
+    ----------
+    lines : list of str
         The lines of the TLE (additional lines allowed)
-    lineno: int (optional)
+    lineno : int, optional
         The line number of the first line for error reporting
 
     Returns
     -------
-    tle: dict
+    tle : dict
         dict of string to string of TLE fields
-    remaining_lines: list of str
+    remaining_lines : list of str
         remaining lines from input
-    lineno_out: int
+    lineno_out : int
         line number of the first of remaining_lines
-
     """
     retval = {}
     if lines[0][0] != "1":


### PR DESCRIPTION
# Description
This PR adds:
- numpydoc linting (with [rules taken from jbpy](https://github.com/ValkyrieSystems/jbpy/blob/ea016512b1afba5f07f8542021f872ad598a0073/pyproject.toml#L28-L36)) and associated style fixes
- an "Install" section to the README